### PR TITLE
Use the GitHub Cache for Docker builds

### DIFF
--- a/.github/workflows/app-build-and-push.yaml
+++ b/.github/workflows/app-build-and-push.yaml
@@ -121,7 +121,8 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          no-cache: true # Waiting for https://github.com/docker/buildx/pull/535
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           file: ./Dockerfile
           platforms: linux/amd64, linux/arm64
           labels: |
@@ -232,7 +233,8 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          no-cache: true # Waiting for https://github.com/docker/buildx/pull/535
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           file: ./Dockerfile
           platforms: linux/amd64, linux/arm64
           labels: |
@@ -317,7 +319,8 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          no-cache: true # Waiting for https://github.com/docker/buildx/pull/535
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           file: ./Dockerfile
           platforms: linux/amd64, linux/arm64
           labels: |


### PR DESCRIPTION
Now that GitHub workers were 100% updated with the new images, let's add caching!
